### PR TITLE
Change travis-ci.org to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 | **Documentation**                                                                                                        | **Build Status**                                                                                |
 |:-------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
-| [![](https://img.shields.io/badge/docs-latest-blue.svg)](https://meggart.github.io/YAXArrays.jl/latest) | [![Build Status](https://travis-ci.org/meggart/YAXArrays.jl.svg?branch=master)](https://travis-ci.org/meggart/YAXArrays.jl)|
+| [![](https://img.shields.io/badge/docs-latest-blue.svg)](https://meggart.github.io/YAXArrays.jl/latest) | [![Build Status](https://travis-ci.com/meggart/YAXArrays.jl.svg?branch=master)](https://travis-ci.com/meggart/YAXArrays.jl)|
 | | [![codecov][codecov-img]](https://codecov.io/github/meggart/YAXArrays.jl?branch=master)
 
 [codecov-img]: https://img.shields.io/codecov/c/github/meggart/YAXArrays.jl/master.svg?label=codecov


### PR DESCRIPTION
The links changed due to a change by travis. This closes #7, because travis was enabled all along, but not visible. 
I believe that the coveralls is not yet working because the travis didn't walk through once.