### PR TITLE
Restrict propertynames(Dataset, private) to avoid ambiguity error in 1.6

### DIFF
--- a/src/DatasetAPI/Datasets.jl
+++ b/src/DatasetAPI/Datasets.jl
@@ -34,7 +34,7 @@ function Base.show(io::IO,ds::Dataset)
     print(io,"Variables: ")
     foreach(i->print(io,i," "),keys(ds.cubes))
 end
-function Base.propertynames(x::Dataset, private=false)
+function Base.propertynames(x::Dataset, private::Bool=false)
     if private
         Symbol[:cubes; :axes; collect(keys(x.cubes)); collect(keys(x.axes))]
     else


### PR DESCRIPTION
In julia 1.6 the optional parameter private in propertynames is restricted to Bool.
This change restricts it also for the method for Dataset, to avoid an ambiguity error.
This fixes the tests on julia 1.6beta.  