### PR TITLE
Setup benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ deps/build.jl
 Manifest.toml
 *.ipynb_checkpoints
 .DS_Store
+# Ignore the benchmarking results
+/benchmark/*.json
+.benchmarkci

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+YAXArrays = "c21b50f5-aa40-41ea-b809-c0f5e47bfa5c"

--- a/benchmark/bench_mapslices.jl
+++ b/benchmark/bench_mapslices.jl
@@ -1,0 +1,13 @@
+module BenchMapCube
+
+using YAXArrays
+using BenchmarkTools
+using Statistics
+using Random
+
+suite = BenchmarkGroup()
+
+suite["small"] = @benchmarkable mapslices(identity, YAXArray(a), dims="Dim_1") setup=(a=rand(1000,1000,10))
+
+end
+BenchMapCube.suite

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,7 @@
+using Pkg
+
+using YAXArrays
+using BenchmarkTools
+
+const SUITE = BenchmarkGroup()
+SUITE["mapslices"] = include("bench_mapslices.jl")


### PR DESCRIPTION
This PR sets up a benchmarking Skeleton, for the usage with BenchmarkCI.
We would need to merge this and then I am going to follow this up with a PR for a  setup of a benchmark GithubAction.

We can sort  the benchmarks as BenchmarkGroups from BenchmarkTools and then define the benchmarks via the  benchmarkable macro. 

You can also run these benchmarks interactively in your local REPL via:
 ```julia
shell> cd ~/.julia/dev/MyProject/

julia> using BenchmarkCI

julia> BenchmarkCI.judge()
...

julia> BenchmarkCI.displayjudgement()
...
```

We would need to discuss proper benchmarks for our usecases and we would also need to check, how we can also benchmark different threading and non-threading scenarios, but maybe we would need to set up another github action workflow. 