### PR TITLE
Add Coveralls to CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,3 +43,7 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
+      - uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./lcov.info

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 | **Documentation**                                                               | **Build Status**                                                                                |
 |:-------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
 | [![][docs-dev-img]][docs-dev-url] | [![][ci-img]][ci-url] [![][codecov-img]][codecov-url] |
+|  |  [![][coveralls-img]][coveralls-url] |
 
 
 [docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
@@ -15,3 +16,6 @@
 
 [ci-img]: https://github.com/meggart/YAXArrays.jl/workflows/CI/badge.svg
 [ci-url]: https://github.com/meggart/YAXArrays.jl/actions?query=workflow%3ACI
+
+[coveralls-img]: https://coveralls.io/repos/github/meggart/YAXArrays.jl/badge.svg?branch=master
+[coveralls-url]: https://coveralls.io/github/meggart/YAXArrays.jl?branch=master


### PR DESCRIPTION
Codecov doesn't show the files for the coverage for me. This adds coveralls so that I could see the actual files. And so that we would have both coverage reports available. 