### PR TITLE
Deploy docs to meggart/YAXArrays.jl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,5 +27,5 @@ makedocs(
 
 deploydocs(
     #deps   = Deps.pip("mkdocs", "python-markdown-math"),
-    repo   = "github.com/esa-esdl/ESDL.jl.git",
+    repo   = "github.com/meggart/YAXArrays.jl.git",
 )


### PR DESCRIPTION
Hopefully this will deploy the docs. 
This fails at the moment, because the repo name is false.