### PR TITLE
Add an api reference to docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,7 @@ end
 makedocs(
     modules = [YAXArrays],
     clean   = true,
-    format   = Documenter.HTML(),
+    format   = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
     sitename = "YAXArrays.jl",
     authors = "Fabian Gans",
     pages    = [ # Compat: `Any` for 0.4 compat
@@ -22,6 +22,7 @@ makedocs(
             "man/applying functions.md",
             "man/iterators.md",
         ],
+        "Docstring Reference" => "api.md"
         ]
 )
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,17 @@
+## Public API
+```@meta
+DocTestSetup= quote
+using YAXArrays
+end
+```
+
+```@autodocs
+Modules = [YAXArrays, YAXArrays.Cubes, YAXArrays.Cubes.Axes, YAXArrays.DAT, YAXArrays.DAT.SentinelMissings, YAXArrays.Datasets,YAXArrays.YAXTools]
+Private = false
+```
+
+## Internal API
+```@autodocs
+Modules = [YAXArrays, YAXArrays.Cubes, YAXArrays.Cubes.Axes, YAXArrays.DAT, YAXArrays.DAT.SentinelMissings,YAXArrays.Datasets,YAXArrays.YAXTools]
+Public = false
+```

--- a/src/Cubes/Axes.jl
+++ b/src/Cubes/Axes.jl
@@ -3,6 +3,9 @@ import ..Cubes: caxes, Cubes
 using Dates
 using Base.Iterators: take, drop
 
+export CubeAxis, RangeAxis, CategoricalAxis,
+getAxis
+
 """
     abstract CubeAxis{T}
 

--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -12,6 +12,8 @@ using ..YAXArrays: workdir, YAXDefaults
 using YAXArrayBase: YAXArrayBase, iscompressed, dimnames, iscontdimval
 import YAXArrayBase: getattributes, iscontdim, dimnames, dimvals, getdata
 
+export concatenatecubes, caxes,
+subsetcube, readcubedata,renameaxis!, YAXArray
 
 """
 This function calculates a subset of a cube's data

--- a/src/DAT/DAT.jl
+++ b/src/DAT/DAT.jl
@@ -1,5 +1,4 @@
 module DAT
-export mapCube
 import ..Cubes
 using ..YAXTools
 using Distributed: RemoteChannel, nworkers,pmap,
@@ -17,6 +16,11 @@ import ProgressMeter: Progress, next!, progress_pmap
 using YAXArrayBase
 using OffsetArrays: OffsetArray
 using Dates
+
+export mapCube, getAxis, InDims, OutDims, Dataset,
+      CubeTable, cubefittable, fittable, savecube, loadcube, rmcube, 
+      MovingWindow 
+
 global const debugDAT=[false]
 
 const WindowDescriptor = Tuple{Int,Int}

--- a/src/DatasetAPI/Datasets.jl
+++ b/src/DatasetAPI/Datasets.jl
@@ -11,6 +11,9 @@ using YAXArrayBase: iscontdimval
 using DiskArrayTools: CFDiskArray, ConcatDiskArray
 using Glob: glob
 
+export Dataset, Cube, open_dataset
+
+
 struct Dataset
     cubes::OrderedDict{Symbol,YAXArray}
     axes::Dict{Symbol,CubeAxis}

--- a/src/YAXArrays.jl
+++ b/src/YAXArrays.jl
@@ -30,15 +30,11 @@ using YAXArrayBase: getattributes
 
 @reexport using Dates: Date, DateTime
 @reexport using IntervalSets: (..)
-@reexport using .Cubes: concatenatecubes, caxes,
-  subsetcube, readcubedata,renameaxis!, YAXArray
-@reexport using .Cubes.Axes: CubeAxis, RangeAxis, CategoricalAxis,
-  getAxis
+@reexport using .Cubes
+@reexport using .Cubes.Axes
 
-@reexport using .DAT: mapCube, getAxis, InDims, OutDims, Dataset,
-      CubeTable, cubefittable, fittable, savecube, loadcube, rmcube, 
-      MovingWindow #From DAT module
-@reexport using .Datasets: Dataset, Cube, open_dataset
+@reexport using .DAT
+@reexport using .Datasets
 @reexport using .YAXTools: @loadOrGenerate # from YAXTools
 
 @deprecate saveCube(data, filename) savecube(data,filename)

--- a/src/YAXTools.jl
+++ b/src/YAXTools.jl
@@ -3,6 +3,8 @@ using Distributed
 import ..YAXArrays: YAXdir
 export freshworkermodule, passobj, @everywhereelsem,
 @loadOrGenerate, PickAxisArray, Window
+
+
 struct PickAxisArray{T,N,AT<:AbstractArray,P,PERM}
   parent::AT
 end


### PR DESCRIPTION
This adds autodocs parts to the documentation.
We need to specify every submodule separately, therefore this long module list.