### PR TITLE
Remove channels and go back to normal pmap

### DIFF
--- a/src/DAT/registration.jl
+++ b/src/DAT/registration.jl
@@ -27,7 +27,7 @@ Axes.findAxis(m::MovingWindow, c) = findAxis(m.desc, c)
 
 wrapWorkArray(::Type{Array}, a, axes) = a
 wrapWorkArray(T, a, axes) =
-    yaxcreate(T, a, map(axname, axes), map(i -> i.values, axes), nothing)
+    yaxcreate(T, a, map(axname, axes), map(i -> i.values, axes), Dict{String, Any}())
 
 abstract type ProcFilter end
 struct AllMissing <: ProcFilter end

--- a/src/DAT/registration.jl
+++ b/src/DAT/registration.jl
@@ -43,16 +43,12 @@ struct UserFilter{F} <: ProcFilter
 end
 
 checkskip(::NoFilter, x) = false
-checkskip(::AllMissing, x::AbstractArray) = all(ismissing, x)
-checkskip(::AllMissing, df::DataFrame) =
-    any(map(i -> all(ismissing, getindex(df, i)), names(df)))
-checkskip(::AnyMissing, x::AbstractArray) = any(ismissing, x)
-checkskip(::AnyMissing, df::DataFrame) =
-    any(map(i -> any(ismissing, getindex(df, i)), names(df)))
-checkskip(nv::NValid, x::AbstractArray) = count(!ismissing, x) <= nv.n
+checkskip(::AllMissing, x) = all(ismissing, x)
+checkskip(::AnyMissing, x) = any(ismissing, x)
+checkskip(nv::NValid, x) = count(!ismissing, x) <= nv.n
 checkskip(uf::UserFilter, x) = uf.f(x)
 checkskip(::StdZero, x) = all(i -> i == x[1], x)
-docheck(pf::ProcFilter, x)::Bool = checkskip(pf, x)
+docheck(pf::ProcFilter, x)::Bool = checkskip(pf, YAXArrayBase.getdata(x))
 docheck(pf::Tuple, x) = reduce(|, map(i -> docheck(i, x), pf))
 
 getprocfilter(f::Function) = (UserFilter(f),)

--- a/src/DatasetAPI/Datasets.jl
+++ b/src/DatasetAPI/Datasets.jl
@@ -3,7 +3,7 @@ import ..Cubes.Axes: axsym, axname, CubeAxis, findAxis, CategoricalAxis, RangeAx
 import ..Cubes: YAXArray, concatenatecubes, CleanMe
 using ...YAXArrays: YAXArrays, YAXDefaults
 using DataStructures: OrderedDict, counter
-using Dates: Day, Hour, Minute, Second, Month, Year, Date, DateTime, TimeType
+using Dates: Day, Hour, Minute, Second, Month, Year, Date, DateTime, TimeType, AbstractDateTime
 using IntervalSets: Interval, (..)
 using CFTime: timedecode, timeencode, DateTimeNoLeap, DateTime360Day, DateTimeAllLeap
 using YAXArrayBase
@@ -142,6 +142,8 @@ propfromattr(attr) = Dict{String,Any}(filter(i -> i[1] != "_ARRAY_DIMENSIONS", a
 #there are problems with saving custom string types to netcdf, so we clean this when creating the axis:
 cleanaxiselement(x::AbstractString) = String(x)
 cleanaxiselement(x::String) = x
+cleanaxiselement(x::TimeType) = DateTime(x)
+cleanaxiselement(x::Union{Date, DateTime}) = x
 cleanaxiselement(x) = x
 
 "Test if data in x can be approximated by a step range"


### PR DESCRIPTION
This should drastically improve error messages in the future, so debugging mapCube functions will get easier again. In the end this was possible by defining `pmap_with_data` which allows some local intitialisation on each worker while keeping everything nicely referenced and garbage-collected after the pmap-call. 