### PR TITLE
Allow size with any Axis describtor

### DIFF
--- a/src/Cubes/Cubes.jl
+++ b/src/Cubes/Cubes.jl
@@ -107,6 +107,7 @@ function YAXArray(x::AbstractArray)
 end
 Base.size(a::YAXArray) = size(getdata(a))
 Base.size(a::YAXArray, i::Int) = size(getdata(a), i)
+Base.size(a::YAXArray, desc) = size(a, findAxis(desc, a))
 function Base.getproperty(a::YAXArray, s::Symbol)
     ax = axsym.(caxes(a))
     i = findfirst(isequal(s), ax)

--- a/test/Cubes/cubes.jl
+++ b/test/Cubes/cubes.jl
@@ -17,8 +17,10 @@ using YAXArrays, YAXArrayBase, Test, Dates
 
     @testset "Basic array Functions" begin
         @test size(a) == (4, 5)
-        @test size(a, 1) == 4
+        @test size(a, 1) == 4     
+        @test size(a, "XVals") == 4
         @test size(a, 2) == 5
+        @test size(a, :YVals) == 5
         @test eltype(a) == Int
         @test ndims(a) == 2
         @test a.XVals == axlist[1]


### PR DESCRIPTION
This allows to call size with describtors instead of Integer values to get the size of a certain axis.
Uses findAxis in the background and therefore accepts the same descriptors. 

This is mainly interesting to call size with String or Symbol descriptors. 
