### PR TITLE
Remove ByFunction axis Descriptor

### DIFF
--- a/src/Cubes/Axes.jl
+++ b/src/Cubes/Axes.jl
@@ -195,16 +195,12 @@ struct ByInference <: AxisDescriptor end
 struct ByValue <: AxisDescriptor
     v::CubeAxis
 end
-struct ByFunction <: AxisDescriptor
-    f::Function
-end
 
 const VecOrTuple{S} = Union{Vector{<:S},Tuple{Vararg{<:S}}} where {S}
 
 get_descriptor(a::String) = ByName(a)
 get_descriptor(a::Symbol) = ByName(String(a))
 get_descriptor(a::CubeAxis) = ByValue(a)
-get_descriptor(a::Function) = ByFunction(a)
 get_descriptor(a) = error("$a is not a valid axis description")
 get_descriptor(a::AxisDescriptor) = a
 
@@ -240,12 +236,6 @@ function getAxis(desc, axlist::VecOrTuple{CubeAxis})
     end
 end
 getOutAxis(desc, axlist, incubes, pargs, f) = getAxis(desc, unique(axlist))
-function getOutAxis(desc::ByFunction, axlist, incubes, pargs, f)
-    outax = desc.f(incubes, pargs)
-    isa(outax, CubeAxis) ||
-        error("Axis Generation function $(desc.f) did not return an axis")
-    outax
-end
 import DataStructures: counter
 function getOutAxis(desc::Tuple{ByInference}, axlist, incubes, pargs, f)
     inAxes = map(caxes, incubes)

--- a/src/DAT/registration.jl
+++ b/src/DAT/registration.jl
@@ -1,5 +1,5 @@
 export InDims, OutDims, MovingWindow
-using ..Cubes.Axes: get_descriptor, ByFunction, findAxis, Axes
+using ..Cubes.Axes: get_descriptor, findAxis, Axes
 using ...YAXArrays: YAXDefaults
 using DataFrames: DataFrame
 using YAXArrayBase: yaxcreate
@@ -86,8 +86,6 @@ function InDims(
     window_oob_value = missing,
 )
     descs = get_descriptor.(axisdesc)
-    any(i -> isa(i, ByFunction), descs) &&
-        error("Input cubes can not be specified through a function")
     InDims(descs, artype, getprocfilter(filter), window_oob_value)
 end
 


### PR DESCRIPTION
The ByFunction AxisDescriptor is unnecessary now that functions don't have to be registered anymore.
This is a breaking change. 
Therefore I would wait with merging this, until the fix_compression branch is ready. 
